### PR TITLE
chore: add `packageManager` field to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "private": true,
+  "packageManager": "npm@10.9.2",
   "workspaces": [
     "packages/*"
   ],


### PR DESCRIPTION
This pull request includes a small change to the `package.json` file. The change specifies the package manager version to be used for the project.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R3): Added `"packageManager": "npm@10.9.2"` to specify the version of npm to be used.