### PR TITLE
chore(*): update `lint-staged` and scripts

### DIFF
--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,8 +1,8 @@
 export default {
   '*': [
-    'npx prettier --check --ignore-unknown',
+    'npx prettier --write --ignore-unknown',
     'npx editorconfig-checker -config .editorconfig-checker.json',
   ],
-  '*.{js,mjs,cjs,jsx,ts,mts,cts,tsx,md}': 'npx eslint',
-  '*.md': 'npx markdownlint',
+  '*.{js,mjs,cjs,jsx,ts,mts,cts,tsx,md}': 'npx eslint --fix',
+  '*.md': 'npx markdownlint --fix',
 };

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "fix": "concurrently \"npm:fix:*\"",
     "fix:eslint": "npx eslint --fix",
     "fix:prettier": "npx prettier . --write --ignore-unknown",
+    "fix:markdownlint": "npx markdownlint **/*.md --fix",
     "lint": "concurrently \"npm:lint:*\"",
     "lint:eslint": "npx eslint",
     "lint:prettier": "npx prettier . --check --ignore-unknown",


### PR DESCRIPTION
This pull request updates the linting and formatting configuration to automatically fix issues where possible, streamlining the development workflow. The most important changes include modifying `lint-staged` to use fix options for Prettier, ESLint, and Markdownlint, and adding a new `fix:markdownlint` script in `package.json`.

### Linting and formatting improvements:

* [`lint-staged.config.mjs`](diffhunk://#diff-7de6c7dbbd1b286aac2271abff52aed05b83379c998f2158f357046f9fd06c7dL3-R7): Updated `lint-staged` configuration to use `--write` for Prettier, `--fix` for ESLint, and `--fix` for Markdownlint, enabling automatic issue resolution during pre-commit checks.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R20): Added a new `fix:markdownlint` script for fixing Markdownlint issues, complementing the existing fix scripts for Prettier and ESLint.