### PR TITLE
refactor(*): convert function declarations to named exports for consistency

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,8 +6,6 @@ import './App.scss';
  *
  * @returns App
  */
-function App() {
+export default function App() {
   return <Start />;
 }
-
-export default App;

--- a/src/components/CompButtonLight/CompButtonLight.jsx
+++ b/src/components/CompButtonLight/CompButtonLight.jsx
@@ -21,7 +21,13 @@ import './CompButtonLight.scss';
  *   null
  * </CompButtonLight>
  */
-function CompButtonLight({ children, style, onClick, neonSize, hoverEffect }) {
+export default function CompButtonLight({
+  children,
+  style,
+  onClick,
+  neonSize,
+  hoverEffect,
+}) {
   return (
     <div className={`CompButtonLight ${hoverEffect ? 'hover' : ''}`}>
       <span style={{ height: neonSize }} />
@@ -48,5 +54,3 @@ CompButtonLight.defaultProps = {
   neonSize: '2px',
   hoverEffect: false,
 };
-
-export default CompButtonLight;

--- a/src/components/CompDivNeon/CompDivNeon.jsx
+++ b/src/components/CompDivNeon/CompDivNeon.jsx
@@ -21,7 +21,13 @@ import './CompDivNeon.scss';
  *   null
  * </CompDivNeon>
  */
-function CompDivNeon({ children, className, neonColor, neonSize, borderWidth }) {
+export default function CompDivNeon({
+  children,
+  className,
+  neonColor,
+  neonSize,
+  borderWidth,
+}) {
   const style = {
     borderWidth,
   };
@@ -63,5 +69,3 @@ CompDivNeon.defaultProps = {
   neonSize: 'l',
   borderWidth: null,
 };
-
-export default CompDivNeon;

--- a/src/components/CompFontNeon/CompFontNeon.jsx
+++ b/src/components/CompFontNeon/CompFontNeon.jsx
@@ -22,7 +22,7 @@ import './CompFontNeon.scss';
  *   null
  * </CompFontNeon>
  */
-function CompFontNeon({
+export default function CompFontNeon({
   children,
   className,
   neonColor,
@@ -74,5 +74,3 @@ CompFontNeon.defaultProps = {
   fontFamily: 'unset',
   fontSize: 'unset',
 };
-
-export default CompFontNeon;

--- a/src/hooks/useConfig.js
+++ b/src/hooks/useConfig.js
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-const useConfig = () => {
+export default function useConfig() {
   /* Hooks */
   // useState
   const [configState, setConfigState] = useState({
@@ -41,6 +41,4 @@ const useConfig = () => {
     handleConfigState,
     isConfigDone,
   };
-};
-
-export default useConfig;
+}

--- a/src/hooks/useContent.js
+++ b/src/hooks/useContent.js
@@ -4,7 +4,7 @@ import { useCallback, useRef } from 'react';
  *
  * @returns
  */
-const useContent = () => {
+export default function useContent() {
   /* Hooks */
   // useRef
   const contentRef = useRef(null);
@@ -23,6 +23,4 @@ const useContent = () => {
     getHTMLContent,
     setHTMLContent,
   };
-};
-
-export default useContent;
+}

--- a/src/hooks/useHistoryRef.js
+++ b/src/hooks/useHistoryRef.js
@@ -4,7 +4,7 @@ import { useCallback, useRef } from 'react';
  *
  * @returns
  */
-const useHistoryRef = () => {
+export default function useHistoryRef() {
   /* Hooks */
   // useRef
   const historyRef = useRef([]);
@@ -19,6 +19,4 @@ const useHistoryRef = () => {
     historyRef,
     addHistory,
   };
-};
-
-export default useHistoryRef;
+}

--- a/src/hooks/useHistoryState.js
+++ b/src/hooks/useHistoryState.js
@@ -4,7 +4,7 @@ import { useCallback, useState } from 'react';
  *
  * @returns
  */
-const useHistoryState = () => {
+export default function useHistoryState() {
   /* Hooks */
   // useState
   const [historyState, setHistoryState] = useState([]);
@@ -19,6 +19,4 @@ const useHistoryState = () => {
     historyState,
     addHistory,
   };
-};
-
-export default useHistoryState;
+}

--- a/src/hooks/useInterview.js
+++ b/src/hooks/useInterview.js
@@ -12,7 +12,7 @@ import {
   fetchFeedback,
 } from '@/utils/openaiService';
 
-const useInterview = () => {
+export default function useInterview() {
   /* Hooks */
   // useInterviewContent
   const { contentRef, getTextContent, setHTMLContent, listening, toggleListening } =
@@ -143,6 +143,4 @@ const useInterview = () => {
     initInterview,
     submit,
   };
-};
-
-export default useInterview;
+}

--- a/src/hooks/useInterviewContent.js
+++ b/src/hooks/useInterviewContent.js
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import useContent from '@/hooks/useContent';
 import useSpeechToText from '@/hooks/useSpeechToText';
 
-const useInterviewContent = () => {
+export default function useInterviewContent() {
   /* Hooks */
   // useContent
   const { contentRef, getTextContent, getHTMLContent, setHTMLContent } = useContent();
@@ -36,6 +36,4 @@ const useInterviewContent = () => {
     listening,
     toggleListening,
   };
-};
-
-export default useInterviewContent;
+}

--- a/src/hooks/useInterviewHistory.js
+++ b/src/hooks/useInterviewHistory.js
@@ -6,7 +6,7 @@ import useHistoryRef from '@/hooks/useHistoryRef';
  *
  * @returns
  */
-const useInterviewHistory = () => {
+export default function useInterviewHistory() {
   /* Hooks */
   // useHistoryRef
   const { historyRef, addHistory } = useHistoryRef();
@@ -93,6 +93,4 @@ const useInterviewHistory = () => {
     getInterviewInfo,
     getInterviewHistory,
   };
-};
-
-export default useInterviewHistory;
+}

--- a/src/hooks/useInterviewObj.js
+++ b/src/hooks/useInterviewObj.js
@@ -12,7 +12,7 @@ const INTERVIEW_OBJ = Object.freeze({
  *
  * @returns
  */
-const useInterviewObj = () => {
+export default function useInterviewObj() {
   /* Hooks */
   // useState
   const [interviewObjState, setInterviewObjState] = useState(INTERVIEW_OBJ);
@@ -66,6 +66,4 @@ const useInterviewObj = () => {
     isOnlyFeedbackEmpty,
     getQuestion,
   };
-};
-
-export default useInterviewObj;
+}

--- a/src/hooks/useScenario.js
+++ b/src/hooks/useScenario.js
@@ -5,7 +5,7 @@ import scenario from '@/data/scenario';
  * scenario > chapter > section => scenario[chapter][section]
  * @returns
  */
-const useScenario = () => {
+export default function useScenario() {
   /* Hooks */
   // useState
   const [state, setState] = useState({
@@ -57,6 +57,4 @@ const useScenario = () => {
     toNextSection,
     toLastSection,
   };
-};
-
-export default useScenario;
+}

--- a/src/hooks/useScroll.js
+++ b/src/hooks/useScroll.js
@@ -4,7 +4,7 @@ import { useCallback, useRef } from 'react';
  *
  * @returns
  */
-const useScroll = () => {
+export default function useScroll() {
   /* Hooks */
   // useRef
   const scrollRef = useRef();
@@ -25,6 +25,4 @@ const useScroll = () => {
     scrollRef,
     scroll,
   };
-};
-
-export default useScroll;
+}

--- a/src/hooks/useSpeechToText.js
+++ b/src/hooks/useSpeechToText.js
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import SpeechRecognition, { useSpeechRecognition } from 'react-speech-recognition';
 
-const useSpeechToText = () => {
+export default function useSpeechToText() {
   /* Hooks */
   // useSpeechRecognition
   const { transcript, listening, resetTranscript } = useSpeechRecognition();
@@ -22,6 +22,4 @@ const useSpeechToText = () => {
     resetTranscript,
     toggleListening,
   };
-};
-
-export default useSpeechToText;
+}

--- a/src/hooks/useTimer.js
+++ b/src/hooks/useTimer.js
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
  * @param {function} callbackOnTimerEnd
  * @returns
  */
-const useTimer = callbackOnTimerEnd => {
+export default function useTimer(callbackOnTimerEnd) {
   /* Hooks */
   // useRef
   const callbackOnTimerEndRef = useRef(callbackOnTimerEnd);
@@ -49,6 +49,4 @@ const useTimer = callbackOnTimerEnd => {
     stopTimer,
     getTimer,
   };
-};
-
-export default useTimer;
+}

--- a/src/hooks/useTrigger.js
+++ b/src/hooks/useTrigger.js
@@ -4,7 +4,7 @@ import { useCallback, useState } from 'react';
  *
  * @returns
  */
-const useTrigger = () => {
+export default function useTrigger() {
   /* Hooks */
   // useState
   const [triggerState, setTriggerState] = useState(false);
@@ -19,6 +19,4 @@ const useTrigger = () => {
     triggerState,
     trigger,
   };
-};
-
-export default useTrigger;
+}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -9,4 +9,4 @@ ReactDOM.createRoot(document.getElementById('App')).render(
   <StrictMode>
     <App />
   </StrictMode>,
-); // React 18 Style
+);

--- a/src/pages/Start/FooterL/FooterL.jsx
+++ b/src/pages/Start/FooterL/FooterL.jsx
@@ -11,7 +11,7 @@ import './FooterL.scss';
  *
  * @returns FooterL
  */
-function FooterL({ scenario }) {
+export default function FooterL({ scenario }) {
   /* Props */
   const { visibility, clickability } = scenario.getSectionObj().FooterL;
 
@@ -37,5 +37,3 @@ FooterL.propTypes = {
   scenario: scenarioPropTypes.isRequired,
 };
 FooterL.defaultProps = {};
-
-export default FooterL;

--- a/src/pages/Start/FooterM/FooterM.jsx
+++ b/src/pages/Start/FooterM/FooterM.jsx
@@ -9,7 +9,7 @@ import './FooterM.scss';
  *
  * @returns FooterM
  */
-function FooterM({ scenario, timer }) {
+export default function FooterM({ scenario, timer }) {
   /* Props */
   const { visibility } = scenario.getSectionObj().FooterM;
   const { getTimer } = timer;
@@ -33,5 +33,3 @@ FooterM.propTypes = {
   timer: timerPropTypes.isRequired,
 };
 FooterM.defaultProps = {};
-
-export default FooterM;

--- a/src/pages/Start/FooterR/FooterR.jsx
+++ b/src/pages/Start/FooterR/FooterR.jsx
@@ -11,7 +11,7 @@ import './FooterR.scss';
  *
  * @returns FooterR
  */
-function FooterR({ scenario, interview, timer }) {
+export default function FooterR({ scenario, interview, timer }) {
   /* Props */
   const { visibility, clickability } = scenario.getSectionObj().FooterR;
   const { submit } = interview;
@@ -42,5 +42,3 @@ FooterR.propTypes = {
   timer: timerPropTypes.isRequired,
 };
 FooterR.defaultProps = {};
-
-export default FooterR;

--- a/src/pages/Start/HeaderL/HeaderL.jsx
+++ b/src/pages/Start/HeaderL/HeaderL.jsx
@@ -11,7 +11,7 @@ import './HeaderL.scss';
  *
  * @returns HeaderL
  */
-function HeaderL({ scenario, config }) {
+export default function HeaderL({ scenario, config }) {
   /* Props */
   const { visibility, clickability } = scenario.getSectionObj().HeaderL;
   const { configState, handleConfigState } = config;
@@ -39,5 +39,3 @@ HeaderL.propTypes = {
   config: configPropTypes.isRequired,
 };
 HeaderL.defaultProps = {};
-
-export default HeaderL;

--- a/src/pages/Start/HeaderR/HeaderR.jsx
+++ b/src/pages/Start/HeaderR/HeaderR.jsx
@@ -11,7 +11,7 @@ import './HeaderR.scss';
  *
  * @returns HeaderR
  */
-function HeaderR({ scenario, interview }) {
+export default function HeaderR({ scenario, interview }) {
   /* Props */
   const { visibility, clickability } = scenario.getSectionObj().HeaderR;
   const { listening, toggleListening } = interview;
@@ -43,5 +43,3 @@ HeaderR.propTypes = {
   interview: interviewPropTypes.isRequired,
 };
 HeaderR.defaultProps = {};
-
-export default HeaderR;

--- a/src/pages/Start/Main/ButtonMain/ButtonMain.jsx
+++ b/src/pages/Start/Main/ButtonMain/ButtonMain.jsx
@@ -14,7 +14,7 @@ import './ButtonMain.scss';
  *
  * @returns ButtonMain
  */
-function ButtonMain({ scenario, config, interview }) {
+export default function ButtonMain({ scenario, config, interview }) {
   /* Props */
   const { getSectionObj, toNextSection, toLastSection } = scenario;
   const { content, visibility: _visibility } = getSectionObj().Main.ButtonMain;
@@ -83,5 +83,3 @@ ButtonMain.propTypes = {
   interview: interviewPropTypes.isRequired,
 };
 ButtonMain.defaultProps = {};
-
-export default ButtonMain;

--- a/src/pages/Start/Main/Heading/Heading.jsx
+++ b/src/pages/Start/Main/Heading/Heading.jsx
@@ -9,7 +9,7 @@ import './Heading.scss';
  *
  * @returns Heading
  */
-function Heading({ scenario }) {
+export default function Heading({ scenario }) {
   /* Props */
   const { visibility } = scenario.getSectionObj().Main.Heading;
 
@@ -33,5 +33,3 @@ Heading.propTypes = {
   scenario: scenarioPropTypes.isRequired,
 };
 Heading.defaultProps = {};
-
-export default Heading;

--- a/src/pages/Start/Main/Main.jsx
+++ b/src/pages/Start/Main/Main.jsx
@@ -21,7 +21,7 @@ import './Main.scss';
  *
  * @returns Main
  */
-function Main({ scenario, config, interview, timer }) {
+export default function Main({ scenario, config, interview, timer }) {
   /* Props */
   const { subsectionState } = scenario;
 
@@ -60,5 +60,3 @@ Main.propTypes = {
   timer: timerPropTypes.isRequired,
 };
 Main.defaultProps = {};
-
-export default Main;

--- a/src/pages/Start/Main/SectionClient/SectionClient.jsx
+++ b/src/pages/Start/Main/SectionClient/SectionClient.jsx
@@ -9,7 +9,7 @@ import './SectionClient.scss';
  *
  * @returns SectionClient
  */
-function SectionClient({ scenario, interview }) {
+export default function SectionClient({ scenario, interview }) {
   /* Props */
   const { visibility } = scenario.getSectionObj().Main.SectionClient;
   const { contentRef } = interview;
@@ -34,5 +34,3 @@ SectionClient.propTypes = {
   interview: interviewPropTypes.isRequired,
 };
 SectionClient.defaultProps = {};
-
-export default SectionClient;

--- a/src/pages/Start/Main/SectionConfig/ButtonCount/ButtonCount.jsx
+++ b/src/pages/Start/Main/SectionConfig/ButtonCount/ButtonCount.jsx
@@ -9,7 +9,7 @@ import './ButtonCount.scss';
  *
  * @returns ButtonCount
  */
-function ButtonCount({ children, onClick, count }) {
+export default function ButtonCount({ children, onClick, count }) {
   /* Return */
   return (
     <CompFontNeon
@@ -35,5 +35,3 @@ ButtonCount.propTypes = {
 ButtonCount.defaultProps = {
   children: null,
 };
-
-export default ButtonCount;

--- a/src/pages/Start/Main/SectionConfig/CheckBox/CheckBox.jsx
+++ b/src/pages/Start/Main/SectionConfig/CheckBox/CheckBox.jsx
@@ -9,7 +9,7 @@ import './CheckBox.scss';
  *
  * @returns CheckBox
  */
-function CheckBox({ children, onChange, isChecked }) {
+export default function CheckBox({ children, onChange, isChecked }) {
   /* Return */
   return (
     <CompFontNeon
@@ -34,5 +34,3 @@ CheckBox.propTypes = {
 CheckBox.defaultProps = {
   children: null,
 };
-
-export default CheckBox;

--- a/src/pages/Start/Main/SectionConfig/SectionConfig.jsx
+++ b/src/pages/Start/Main/SectionConfig/SectionConfig.jsx
@@ -12,7 +12,7 @@ import './SectionConfig.scss';
  *
  * @returns SectionConfig
  */
-function SectionConfig({ config }) {
+export default function SectionConfig({ config }) {
   /* Props */
   const { configState, handleConfigState } = config;
   const questionTypeKeys = Object.keys(configState.questionType);
@@ -77,5 +77,3 @@ SectionConfig.propTypes = {
   config: configPropTypes.isRequired,
 };
 SectionConfig.defaultProps = {};
-
-export default SectionConfig;

--- a/src/pages/Start/Main/SectionResult/SectionResult.jsx
+++ b/src/pages/Start/Main/SectionResult/SectionResult.jsx
@@ -9,7 +9,7 @@ import './SectionResult.scss';
  *
  * @returns SectionResult
  */
-function SectionResult() {
+export default function SectionResult() {
   /* Return */
   return (
     <CompDivNeon className="SectionResult invisible" neonSize="s" neonColor="violet">
@@ -27,5 +27,3 @@ function SectionResult() {
 }
 SectionResult.propTypes = {};
 SectionResult.defaultProps = {};
-
-export default SectionResult;

--- a/src/pages/Start/Main/SectionServer/SectionServer.jsx
+++ b/src/pages/Start/Main/SectionServer/SectionServer.jsx
@@ -17,7 +17,7 @@ import './SectionServer.scss';
  *
  * @returns SectionServer
  */
-function SectionServer({ scenario, config, interview, timer }) {
+export default function SectionServer({ scenario, config, interview, timer }) {
   /* Props */
   const { subsectionState, getSectionObj, toNextSection } = scenario;
   const { auto, api, result } = getSectionObj().global;
@@ -90,5 +90,3 @@ SectionServer.propTypes = {
   timer: timerPropTypes.isRequired,
 };
 SectionServer.defaultProps = {};
-
-export default SectionServer;

--- a/src/pages/Start/Start.jsx
+++ b/src/pages/Start/Start.jsx
@@ -18,7 +18,7 @@ import './Start.scss';
  *
  * @returns Start
  */
-function Start() {
+export default function Start() {
   /* Hooks */
   const scenario = useScenario();
   const config = useConfig();
@@ -37,5 +37,3 @@ function Start() {
     </div>
   );
 }
-
-export default Start;


### PR DESCRIPTION
This pull request refactors the codebase by converting all component and hook declarations to use named `export default` functions. This change improves consistency and simplifies the code structure by removing redundant `export default` statements at the end of each file.

### Component Refactoring:
* Updated `App`, `CompButtonLight`, `CompDivNeon`, `CompFontNeon`, `FooterL`, and `FooterM` components to use `export default` inline with their function declarations. Removed redundant `export default` statements. (`[[1]](diffhunk://#diff-d274a54187c91ba0f532df2a9e194e27ab50e988f5e4c33f5a7893918320c661L9-L13)`, `[[2]](diffhunk://#diff-ca0ced5a304cce5a864860781eb8213a0fb75adc09378ed388aa0614518c2a28L24-R30)`, `[[3]](diffhunk://#diff-ca0ced5a304cce5a864860781eb8213a0fb75adc09378ed388aa0614518c2a28L51-L52)`, `[[4]](diffhunk://#diff-03478f54133fd7e74549a4b40535c8f6e29a35349c24530f98e9849657b81042L24-R30)`, `[[5]](diffhunk://#diff-03478f54133fd7e74549a4b40535c8f6e29a35349c24530f98e9849657b81042L66-L67)`, `[[6]](diffhunk://#diff-1bfb1631cde9bb1f524242e158c3c40bab99eb8a1d04b54ddd15874c060a6148L25-R25)`, `[[7]](diffhunk://#diff-1bfb1631cde9bb1f524242e158c3c40bab99eb8a1d04b54ddd15874c060a6148L77-L78)`, `[[8]](diffhunk://#diff-0623c7191608496f4acf15e5e6e1d57fc81c74cf4f756c5cec544998810aec17L14-R14)`, `[[9]](diffhunk://#diff-0623c7191608496f4acf15e5e6e1d57fc81c74cf4f756c5cec544998810aec17L40-L41)`, `[[10]](diffhunk://#diff-f9d09028eb8c917e5bf10ddd686361644152ba8bdda9147f8ba9eaf4042e9784L12-R12)`, `[[11]](diffhunk://#diff-f9d09028eb8c917e5bf10ddd686361644152ba8bdda9147f8ba9eaf4042e9784L36-L37)`)

### Hook Refactoring:
* Updated all custom hooks (`useConfig`, `useContent`, `useHistoryRef`, `useHistoryState`, `useInterview`, `useInterviewContent`, `useInterviewHistory`, `useInterviewObj`, `useScenario`, `useScroll`, `useSpeechToText`, `useTimer`, and `useTrigger`) to use `export default` inline with their function declarations. Removed redundant `export default` statements. (`[[1]](diffhunk://#diff-d0232ef333f6ca2f19da51087f1fcec8ae4abf5ee850e26ee4958d29d12a32ceL3-R3)`, `[[2]](diffhunk://#diff-d0232ef333f6ca2f19da51087f1fcec8ae4abf5ee850e26ee4958d29d12a32ceL44-R44)`, `[[3]](diffhunk://#diff-3f7835d49e1f4623e765f7129bf279155ae45518d0632a1f075c24b2aac444eaL7-R7)`, `[[4]](diffhunk://#diff-3f7835d49e1f4623e765f7129bf279155ae45518d0632a1f075c24b2aac444eaL26-R26)`, `[[5]](diffhunk://#diff-a25c6bcb5ac0c5ca5585f14f5266e8d22146394f364f5fbcebf6408a130ef878L7-R7)`, `[[6]](diffhunk://#diff-a25c6bcb5ac0c5ca5585f14f5266e8d22146394f364f5fbcebf6408a130ef878L22-R22)`, `[[7]](diffhunk://#diff-2b0bd8516beb1826303048bb082c01ef41b48e66f32f78c2bd7effc17292b984L7-R7)`, `[[8]](diffhunk://#diff-2b0bd8516beb1826303048bb082c01ef41b48e66f32f78c2bd7effc17292b984L22-R22)`, `[[9]](diffhunk://#diff-f2b913e488d383826b34f8c5a66ec7d4a6ddc7fbad44054927d744bef2c2f89fL15-R15)`, `[[10]](diffhunk://#diff-f2b913e488d383826b34f8c5a66ec7d4a6ddc7fbad44054927d744bef2c2f89fL146-R146)`, `[[11]](diffhunk://#diff-44584afb89d102d31d2cb0e8eccfcc29a5ca05ba761b4a675e054a34c1db01d6L6-R6)`, `[[12]](diffhunk://#diff-44584afb89d102d31d2cb0e8eccfcc29a5ca05ba761b4a675e054a34c1db01d6L39-R39)`, `[[13]](diffhunk://#diff-2edc345cea0024ae3fbce30da06423fb945f1230996f4aaa25222784ed755ca9L9-R9)`, `[[14]](diffhunk://#diff-2edc345cea0024ae3fbce30da06423fb945f1230996f4aaa25222784ed755ca9L96-R96)`, `[[15]](diffhunk://#diff-1f971055cf1440bac36cd77ed8c9fd6cf41d036a6ba301e95c834cbb64b2d5c7L15-R15)`, `[[16]](diffhunk://#diff-1f971055cf1440bac36cd77ed8c9fd6cf41d036a6ba301e95c834cbb64b2d5c7L69-R69)`, `[[17]](diffhunk://#diff-f080fe7c231d41060cd2d54102f5db6654aba20ec02c2bf4039b7498e8730045L8-R8)`, `[[18]](diffhunk://#diff-f080fe7c231d41060cd2d54102f5db6654aba20ec02c2bf4039b7498e8730045L60-R60)`, `[[19]](diffhunk://#diff-f7739783097b06e0702401ae6556715d74959e7052b8732b9d021a78b2a53316L7-R7)`, `[[20]](diffhunk://#diff-f7739783097b06e0702401ae6556715d74959e7052b8732b9d021a78b2a53316L28-R28)`, `[[21]](diffhunk://#diff-5b1d0b671786bc57450635e84b75be72211a19f0a6407062c4e2b0596394cb5dL4-R4)`, `[[22]](diffhunk://#diff-5b1d0b671786bc57450635e84b75be72211a19f0a6407062c4e2b0596394cb5dL25-R25)`, `[[23]](diffhunk://#diff-30e245028a7317ede1736455d4d9204ce5f5924f59e243e9ccc0c5e43636df85L8-R8)`, `[[24]](diffhunk://#diff-30e245028a7317ede1736455d4d9204ce5f5924f59e243e9ccc0c5e43636df85L52-R52)`, `[[25]](diffhunk://#diff-05828c97957400e96c0631c2ac0a27010eca4e1908a6abdedf931bef326ff4c1L7-R7)`, `[[26]](diffhunk://#diff-05828c97957400e96c0631c2ac0a27010eca4e1908a6abdedf931bef326ff4c1L22-R22)`)

### Miscellaneous:
* Removed a comment in `src/index.jsx` about React 18 style for `ReactDOM.createRoot`. (`[src/index.jsxL12-R12](diffhunk://#diff-ec767e14d91498b5b31a4ce826c4596061eb83a47d3dee00f6cbe1078232a75cL12-R12)`)