### PR TITLE
refactor(*): migrate to Node.js native `.env`

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,5 +1,8 @@
 {
   "private": true,
+  "engines": {
+    "node": ">=20.18.0"
+  },
   "scripts": {
     "start": "node --env-file=.env --watch ./src/server.js"
   },

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,10 +1,9 @@
 {
   "private": true,
   "scripts": {
-    "start": "node --watch ./src/server.js"
+    "start": "node --env-file=.env --watch ./src/server.js"
   },
   "dependencies": {
-    "dotenv": "^17.1.0",
     "openai": "^4.104.0",
     "qs": "^6.14.0"
   }

--- a/apps/backend/src/server.js
+++ b/apps/backend/src/server.js
@@ -1,15 +1,12 @@
 const http = require('node:http');
 const url = require('node:url');
 const qs = require('qs');
-const dotenv = require('dotenv');
 const {
   fetchQuestionMain,
   fetchQuestionSub,
   fetchAnswer,
   fetchFeedback,
 } = require('./services/openaiService');
-
-dotenv.config();
 
 /* Func */
 const response = (res, code, text) => {

--- a/apps/backend/src/services/openaiInstance.js
+++ b/apps/backend/src/services/openaiInstance.js
@@ -1,7 +1,4 @@
 const OpenAI = require('openai');
-const dotenv = require('dotenv');
-
-dotenv.config();
 
 const openaiInstance = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY,

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,6 @@
     },
     "apps/backend": {
       "dependencies": {
-        "dotenv": "^17.1.0",
         "openai": "^4.104.0",
         "qs": "^6.14.0"
       }
@@ -1944,19 +1943,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
@@ -5449,6 +5435,7 @@
       "version": "17.1.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.1.0.tgz",
       "integrity": "sha512-tG9VUTJTuju6GcXgbdsOuRhupE8cb4mRgY5JLRCh4MtGoVo3/gfGUtOMwmProM6d0ba2mCFvv+WrpYJV6qgJXQ==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -7423,6 +7410,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/globalthis": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,9 @@
       "dependencies": {
         "openai": "^4.104.0",
         "qs": "^6.14.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       }
     },
     "node_modules/@ampproject/remapping": {


### PR DESCRIPTION
This pull request updates the backend application to streamline environment variable management and improve the startup process. The most important changes involve removing redundant `dotenv` usage and updating the `start` script to load environment variables directly.

### Environment Variable Management:
* Removed redundant `dotenv` initialization from `apps/backend/src/server.js` and `apps/backend/src/services/openaiInstance.js`, as environment variables are now loaded directly through the `start` script. [[1]](diffhunk://#diff-5086787e3529f754030141a32207b3b34300cedaf2232c9775ae13d0dddda6f1L4-L13) [[2]](diffhunk://#diff-57a550fe0928418e5f0ba8d21843b7e554ecb0fe2ce9f7f08aefe9f45a12fef1L2-L4)

### Startup Process:
* Updated the `start` script in `apps/backend/package.json` to include `--env-file=.env`, enabling direct loading of environment variables without requiring `dotenv`.