### PR TITLE
chore(*): move `FUNDING.yml` to `.github` repository

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,0 @@
-github: [lumirlumir]
-open_collective: lumirlumir

--- a/.github/sync-client.yml
+++ b/.github/sync-client.yml
@@ -18,8 +18,6 @@ lumirlumir/lumirlumir-configs:
   # ./.github
   - source: ./.github/CODEOWNERS
     dest: ./configs/.github/CODEOWNERS
-  - source: ./.github/FUNDING.yml
-    dest: ./configs/.github/FUNDING.yml
   - source: ./.github/PULL_REQUEST_TEMPLATE.md
     dest: ./configs/.github/PULL_REQUEST_TEMPLATE.md
   - source: ./.github/dependabot.yml


### PR DESCRIPTION
This pull request removes references to the `FUNDING.yml` file and updates the synchronization configuration to exclude it. These changes simplify the repository by removing outdated funding information and ensuring synchronization settings are consistent.

### Removal of funding information:
* [`.github/FUNDING.yml`](diffhunk://#diff-07985fdcade0e64d11482724879a644f07879ba61b8fb6c6119e1b1902b72ae4L1-L2): Deleted funding details for GitHub and Open Collective.

### Update to synchronization configuration:
* [`.github/sync-client.yml`](diffhunk://#diff-93bc202766315b6269beef308a6ad30ed3e86938ddbfa31b49e030f2263695f1L21-L22): Removed the synchronization entry for `FUNDING.yml` to prevent syncing this file in the future.