### PR TITLE
chore(*): drop `webpack-cli`

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,4 @@
-import { fileURLToPath } from 'node:url';
-import { dirname, resolve } from 'node:path';
-
+import { resolve } from 'node:path';
 import bananass from 'eslint-config-bananass';
 import mark from 'eslint-plugin-mark';
 
@@ -18,9 +16,8 @@ export default [
       node: {
         resolverConfig: {
           // `eslint-plugin-n` uses webpack's `enhanced-resolve` under the hood.
-          // TODO: Sync with `webpack.config.js`.
           alias: {
-            '@': resolve(dirname(fileURLToPath(import.meta.url)), 'src'),
+            '@': resolve(import.meta.dirname, 'src'),
           },
         },
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,6 @@
         "style-loader": "^4.0.0",
         "typescript": "^5.9.2",
         "webpack": "^5.101.0",
-        "webpack-cli": "^6.0.1",
         "webpack-dev-server": "^5.2.2"
       },
       "engines": {
@@ -1827,16 +1826,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@discoveryjs/json-ext": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.6.3.tgz",
-      "integrity": "sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.17.0"
-      }
-    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
@@ -3206,53 +3195,6 @@
         "@xtuc/long": "4.2.2"
       }
     },
-    "node_modules/@webpack-cli/configtest": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-3.0.1.tgz",
-      "integrity": "sha512-u8d0pJ5YFgneF/GuvEiDA61Tf1VDomHHYMjv/wc9XzYj7nopltpG96nXN5dJRstxZhcNpV1g+nT6CydO7pHbjA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "peerDependencies": {
-        "webpack": "^5.82.0",
-        "webpack-cli": "6.x.x"
-      }
-    },
-    "node_modules/@webpack-cli/info": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-3.0.1.tgz",
-      "integrity": "sha512-coEmDzc2u/ffMvuW9aCjoRzNSPDl/XLuhPdlFRpT9tZHmJ/039az33CE7uH+8s0uL1j5ZNtfdv0HkfaKRBGJsQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "peerDependencies": {
-        "webpack": "^5.82.0",
-        "webpack-cli": "6.x.x"
-      }
-    },
-    "node_modules/@webpack-cli/serve": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-3.0.1.tgz",
-      "integrity": "sha512-sbgw03xQaCLiT6gcY/6u3qBDn01CWw/nbaXl3gTdTFuJJ75Gffv3E3DBpgvY2fkkrdS1fpjaXNOmJlnbtKauKg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "peerDependencies": {
-        "webpack": "^5.82.0",
-        "webpack-cli": "6.x.x"
-      },
-      "peerDependenciesMeta": {
-        "webpack-dev-server": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -4356,20 +4298,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/clone-deep": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
-      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
-      "dev": true,
-      "dependencies": {
-        "is-plain-object": "^2.0.4",
-        "kind-of": "^6.0.2",
-        "shallow-clone": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -6670,15 +6598,6 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/fastest-levenshtein": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
-      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4.9.1"
-      }
-    },
     "node_modules/fastq": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
@@ -6796,15 +6715,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/flat": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
-      "dev": true,
-      "bin": {
-        "flat": "cli.js"
       }
     },
     "node_modules/flat-cache": {
@@ -7736,25 +7646,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/import-local": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
-      "integrity": "sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==",
-      "dev": true,
-      "dependencies": {
-        "pkg-dir": "^4.2.0",
-        "resolve-cwd": "^3.0.0"
-      },
-      "bin": {
-        "import-local-fixture": "fixtures/cli.js"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -7783,15 +7674,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/interpret": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
-      "integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.13.0"
       }
     },
     "node_modules/ipaddr.js": {
@@ -8174,18 +8056,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-plain-object": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "dev": true,
-      "dependencies": {
-        "isobject": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -8357,15 +8227,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
-    },
-    "node_modules/isobject": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
@@ -8556,15 +8417,6 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
-      }
-    },
-    "node_modules/kind-of": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/language-subtag-registry": {
@@ -11212,18 +11064,6 @@
         "node": ">=8.10.0"
       }
     },
-    "node_modules/rechoir": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
-      "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
-      "dev": true,
-      "dependencies": {
-        "resolve": "^1.20.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      }
-    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -11408,27 +11248,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/resolve-cwd": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
-      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
-      "dev": true,
-      "dependencies": {
-        "resolve-from": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/resolve-from": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -12018,18 +11837,6 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/shallow-clone": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
-      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
-      "dev": true,
-      "dependencies": {
-        "kind-of": "^6.0.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -13358,72 +13165,6 @@
         }
       }
     },
-    "node_modules/webpack-cli": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-6.0.1.tgz",
-      "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@discoveryjs/json-ext": "^0.6.1",
-        "@webpack-cli/configtest": "^3.0.1",
-        "@webpack-cli/info": "^3.0.1",
-        "@webpack-cli/serve": "^3.0.1",
-        "colorette": "^2.0.14",
-        "commander": "^12.1.0",
-        "cross-spawn": "^7.0.3",
-        "envinfo": "^7.14.0",
-        "fastest-levenshtein": "^1.0.12",
-        "import-local": "^3.0.2",
-        "interpret": "^3.1.1",
-        "rechoir": "^0.8.0",
-        "webpack-merge": "^6.0.1"
-      },
-      "bin": {
-        "webpack-cli": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.82.0"
-      },
-      "peerDependenciesMeta": {
-        "webpack-bundle-analyzer": {
-          "optional": true
-        },
-        "webpack-dev-server": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/webpack-cli/node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/webpack-cli/node_modules/envinfo": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.14.0.tgz",
-      "integrity": "sha512-CO40UI41xDQzhLB1hWyqUKgFhs250pNcGbyGKe1l/e4FSaI/+YE4IMG76GDt0In67WLPACIITC+sOi08x4wIvg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "envinfo": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/webpack-dev-middleware": {
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-7.4.2.tgz",
@@ -13510,21 +13251,6 @@
         "webpack-cli": {
           "optional": true
         }
-      }
-    },
-    "node_modules/webpack-merge": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
-      "integrity": "sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/webpack-sources": {
@@ -13680,13 +13406,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/wildcard": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
-      "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "repository": "https://github.com/lumirlumir/web-moing.lumir.page",
   "scripts": {
     "prepare": "husky",
-    "dev": "npx webpack serve --mode=development --open",
-    "build": "npx webpack build --mode=production",
+    "dev": "node ./webpack.config.mjs dev",
+    "build": "node ./webpack.config.mjs build",
     "deploy": "gh-pages -d build",
     "fix": "concurrently \"npm:fix:*\"",
     "fix:eslint": "npx eslint --fix",
@@ -59,7 +59,6 @@
     "style-loader": "^4.0.0",
     "typescript": "^5.9.2",
     "webpack": "^5.101.0",
-    "webpack-cli": "^6.0.1",
     "webpack-dev-server": "^5.2.2"
   }
 }


### PR DESCRIPTION
This pull request refactors the project's development and build workflow to use a custom Node.js script (`webpack.config.mjs`) instead of relying on `webpack-cli`. It also updates how path resolution and environment loading are handled, and cleans up related dependencies. The main changes are grouped below:

**Development and Build Workflow Overhaul:**

* Replaces `webpack-cli` with direct Node.js script commands for development and production builds in `package.json` scripts (`dev` and `build` now run `node ./webpack.config.mjs dev|build` instead of `npx webpack ...`).
* Removes the `webpack-cli` dependency from `package.json` since it is no longer needed.
* Adds a new implementation in `webpack.config.mjs` that directly starts the webpack dev server or runs the build based on the command-line argument, providing custom logging and error handling. [[1]](diffhunk://#diff-504be09670485a92ff6bcb692041129e877eda9058a8c3114c42a53a0e0d1194R1-R45) [[2]](diffhunk://#diff-504be09670485a92ff6bcb692041129e877eda9058a8c3114c42a53a0e0d1194R104-R133)

**Path and Alias Resolution Improvements:**

* Updates alias resolution in both `eslint.config.mjs` and `webpack.config.mjs` to use `import.meta.dirname` for more robust path handling, removing the need for `fileURLToPath` and `dirname`. [[1]](diffhunk://#diff-9601a8f6c734c2001be34a2361f76946d19a39a709b5e8c624a2a5a0aade05f2L1-R1) [[2]](diffhunk://#diff-9601a8f6c734c2001be34a2361f76946d19a39a709b5e8c624a2a5a0aade05f2L21-R20) [[3]](diffhunk://#diff-504be09670485a92ff6bcb692041129e877eda9058a8c3114c42a53a0e0d1194R1-R45)

**Environment Handling:**

* Loads environment variables from `.env` within `webpack.config.mjs` and adds error handling for missing files, ensuring consistent environment setup for both dev and build modes.

These changes streamline the development workflow, reduce dependencies, and improve maintainability by consolidating build logic into a single script.