### PR TITLE
refactor(*): replace `qs` with native helpers

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -9,7 +9,6 @@
     "test": "tsc --noEmit"
   },
   "dependencies": {
-    "openai": "^4.104.0",
-    "qs": "^6.14.0"
+    "openai": "^4.104.0"
   }
 }

--- a/apps/backend/src/server.js
+++ b/apps/backend/src/server.js
@@ -8,7 +8,6 @@
 
 import http from 'node:http';
 import url from 'node:url';
-import qs from 'qs';
 import {
   fetchQuestionMain,
   fetchQuestionSub,
@@ -34,42 +33,40 @@ http
     res.setHeader('Access-Control-Allow-Origin', process.env.FRONTEND_URL); // CORS
 
     const { pathname, query } = url.parse(req.url); // eslint-disable-line n/no-deprecated-api -- TODO: delete it later.
-    const queryParsed = qs.parse(query); // for array
+    const urlSearchParams = new URLSearchParams(query); // for array
 
     console.log(`TIME: ${new Date()}\nMETHOD: ${req.method}\nURL: ${req.url}`); // eslint-disable-line no-console -- for debugging.
-    console.log(queryParsed, '\n'); // eslint-disable-line no-console -- for debugging.
+    console.log(urlSearchParams, '\n'); // eslint-disable-line no-console -- for debugging.
 
     if (req.method === 'GET') {
       switch (pathname) {
         case '/question/main': {
-          const { type, history } = queryParsed;
+          const type = urlSearchParams.get('type');
+          const history = urlSearchParams.getAll('history');
 
           // @ts-expect-error -- TODO
-          fetchQuestionMain(type, typeof history === 'undefined' ? [] : history).then(
-            result => response(res, 200, result),
-          );
+          fetchQuestionMain(type, history).then(result => response(res, 200, result));
           break;
         }
         case '/question/sub': {
-          const { question, answerUser } = queryParsed;
+          const question = urlSearchParams.get('question');
+          const answerUser = urlSearchParams.get('answerUser');
 
-          // @ts-expect-error -- TODO
           fetchQuestionSub(question, answerUser).then(result =>
             response(res, 200, result),
           );
           break;
         }
         case '/answer': {
-          const { question } = queryParsed;
+          const question = urlSearchParams.get('question');
 
-          // @ts-expect-error -- TODO
           fetchAnswer(question).then(result => response(res, 200, result));
           break;
         }
         case '/feedback': {
-          const { answerSystem, answerUser } = queryParsed;
+          const answerSystem = urlSearchParams.get('answerSystem');
+          const answerUser = urlSearchParams.get('answerUser');
 
-          // @ts-expect-error -- TODO
           fetchFeedback(answerSystem, answerUser).then(result =>
             response(res, 200, result),
           );

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
         "apps/*"
       ],
       "dependencies": {
-        "qs": "^6.14.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-speech-recognition": "^4.0.1"
@@ -48,8 +47,7 @@
     },
     "apps/backend": {
       "dependencies": {
-        "openai": "^4.104.0",
-        "qs": "^6.14.0"
+        "openai": "^4.104.0"
       },
       "engines": {
         "node": ">=20.19.4"
@@ -4132,22 +4130,6 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
-    "node_modules/body-parser/node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.0.6"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/bonjour-service": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.2.1.tgz",
@@ -4287,6 +4269,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -6584,22 +6567,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/express/node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.0.6"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -10275,6 +10242,7 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10985,12 +10953,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "side-channel": "^1.0.6"
       },
       "engines": {
         "node": ">=0.6"
@@ -11931,6 +11900,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -11950,6 +11920,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -11966,6 +11937,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -11984,6 +11956,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "lint:todo": "npx tsc --noEmit && npm run test -w apps/backend"
   },
   "dependencies": {
-    "qs": "^6.14.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-speech-recognition": "^4.0.1"

--- a/src/hooks/use-config.ts
+++ b/src/hooks/use-config.ts
@@ -71,6 +71,8 @@ export interface Config {
   time: number;
 }
 
+export type QuestionType = (typeof questionTypes)[number];
+
 // --------------------------------------------------------------------------------
 // Export
 // --------------------------------------------------------------------------------


### PR DESCRIPTION
This pull request refactors how query parameters are handled in both the backend and frontend, removing the dependency on the `qs` library and replacing it with the native `URLSearchParams` API. This change simplifies the codebase, improves type safety, and ensures more consistent handling of array parameters in API calls.

**Backend dependency and query parsing refactor:**

* Removed the `qs` package from both `apps/backend/package.json` and the main project `package.json`, eliminating an unnecessary dependency. [[1]](diffhunk://#diff-8d3b741039fe624dded05aa46e994d93ec459ac8d8a0cfc747f92ef447a9513aL12-R12) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L29)
* Updated `apps/backend/src/server.js` to use `URLSearchParams` instead of `qs` for parsing query strings, and refactored all API endpoint handlers to retrieve parameters using the native API. [[1]](diffhunk://#diff-5086787e3529f754030141a32207b3b34300cedaf2232c9775ae13d0dddda6f1L11) [[2]](diffhunk://#diff-5086787e3529f754030141a32207b3b34300cedaf2232c9775ae13d0dddda6f1L37-L72)

**Frontend fetch logic and type improvements:**

* Removed `qs` from the frontend (`src/hooks/use-interview.ts`) and refactored all fetch helper functions to use `URLSearchParams`, ensuring proper handling of array parameters and improving readability.
* Added a new type alias `QuestionType` in `src/hooks/use-config.ts` for improved type safety in API calls.
* Updated usages of fetch helpers and related callbacks to work with the new parameter handling and types, including minor code cleanups. [[1]](diffhunk://#diff-65ddf5f962953ece71f424d4e7c74320d7e55bc07404f6661345c644680a3d6aL65-R103) [[2]](diffhunk://#diff-65ddf5f962953ece71f424d4e7c74320d7e55bc07404f6661345c644680a3d6aL137-R176)